### PR TITLE
Fix JSON error that is preventing indexing of this module

### DIFF
--- a/META.info
+++ b/META.info
@@ -5,7 +5,7 @@
     "depends"     : [ "JSON::Tiny" ],
     "provides"    : {
         "ANTLR4::Grammar"            : "lib/ANTLR4/Grammar.pm",
-        "ANTLR4::Grammar::Actions"   : "lib/ANTLR4/Grammar/Actions.pm",
+        "ANTLR4::Grammar::Actions"   : "lib/ANTLR4/Grammar/Actions.pm"
     },
     "source-url"  : "git://github.com/drforr/perl6-ANTLR4.git"
 }


### PR DESCRIPTION
The META.info file is read as JSON by the indexer and the error is preventing the module from being listed on modules.perl6.org