### PR TITLE
Fix number of corpus tests

### DIFF
--- a/t/02-corpus.t
+++ b/t/02-corpus.t
@@ -3,7 +3,7 @@ BEGIN { @*INC.push('lib') };
 use ANTLR4::Grammar;
 use Test;
 
-plan 56;
+plan 55;
 
 my $g = ANTLR4::Grammar.new;
 


### PR DESCRIPTION
The VisualBasic test has been commented out, thus the number of planned
tests differs from that actually run.  This change brings the planned and
actual numbers back in sync.