### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/01-parse.t
+++ b/t/01-parse.t
@@ -1,5 +1,5 @@
 use v6;
-BEGIN { @*INC.push('lib') };
+use lib 'lib';
 use ANTLR4::Grammar;
 use Test;
 

--- a/t/02-corpus.t
+++ b/t/02-corpus.t
@@ -1,5 +1,5 @@
 use v6;
-BEGIN { @*INC.push('lib') };
+use lib 'lib';
 use ANTLR4::Grammar;
 use Test;
 

--- a/t/03-ast.t
+++ b/t/03-ast.t
@@ -1,5 +1,5 @@
 use v6;
-BEGIN { @*INC.push('lib') };
+use lib 'lib';
 use ANTLR4::Grammar;
 use ANTLR4::Actions::AST;
 use Test;

--- a/t/04-perl6.t
+++ b/t/04-perl6.t
@@ -1,5 +1,5 @@
 use v6;
-BEGIN { @*INC.push('lib') };
+use lib 'lib';
 use ANTLR4::Actions::Perl6;
 use Test;
 


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.